### PR TITLE
Fixed fatal error: Cannot read property 'length' of null

### DIFF
--- a/tasks/docker_io.js
+++ b/tasks/docker_io.js
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
       dockerLogin.stdout.on('data', function(data){
         data = data || ''
         var usernameRegex = /\(.*\)/
-        if(usernameRegex.exec(data).length > 0) {
+        if(usernameRegex.exec(data) && usernameRegex.exec(data).length > 0) {
           if(usernameRegex.exec(data)[0] !== '(' + opts.username + ')'){
             grunt.fatal('Please Login First')
           }


### PR DESCRIPTION
This PR fixes a fatal error which occurs if a user is not logged in as exec() returns null when there are no regex results.
